### PR TITLE
Move config manipulation to middleware loaded before all other middlewares

### DIFF
--- a/config/functions/bootstrap.js
+++ b/config/functions/bootstrap.js
@@ -22,22 +22,6 @@ const PUBLIC_ROLE_ID = 2
 module.exports = async () => {
   const log = strapi.log.child({ module: 'bootstrap' })
 
-  // fill origins if they are not set
-  const self = new URL(strapi.config.origin.self)
-  const prefixes = ['id', 'investor', 'company']
-  prefixes.forEach((prefix) => {
-    if (strapi.config.origin[prefix] === '') {
-      const prefixUrl = new URL('', self)
-      prefixUrl.hostname = `${prefix}.${self.hostname}`
-      strapi.config.origin[prefix] = prefixUrl.origin
-    }
-  })
-
-  // fill domains if they are not set
-  if (strapi.config.hostname.shared === '') {
-    strapi.config.hostname.shared = `.${self.hostname}`
-  }
-
   // Enable public access to some controllers on init
   await strapi.plugins['users-permissions'].services.userspermissions
     .updateRole(PUBLIC_ROLE_ID, {
@@ -130,25 +114,6 @@ module.exports = async () => {
           root: s3Config.root,
         }
       })
-  }
-
-  if (strapi.config.currentEnvironment.security.cors.enabled === true) {
-    const { origin: initialOrigin } = strapi.config.middleware.settings.cors
-    const initialOriginArray = Array.isArray(initialOrigin)
-      ? initialOrigin
-      : initialOrigin.split(/\s*,\s*/)
-
-    const allowedOrigin = new Set([
-      ...initialOriginArray,
-      strapi.config.origin.self,
-      strapi.config.origin.id,
-      strapi.config.origin.investor,
-      strapi.config.origin.company,
-    ])
-
-    allowedOrigin.delete('')
-
-    strapi.config.middleware.settings.cors.origin = [...allowedOrigin]
   }
 
   if (strapi.config.environment !== 'development') {

--- a/config/middleware.json
+++ b/config/middleware.json
@@ -2,6 +2,7 @@
   "timeout": 100,
   "load": {
     "before": [
+      "update-config-before-middlewares",
       "responseTime",
       "logger",
       "cors",

--- a/middlewares/update-config-before-middlewares/defaults.json
+++ b/middlewares/update-config-before-middlewares/defaults.json
@@ -1,0 +1,5 @@
+{
+  "update-config-before-middlewares": {
+    "enabled": true
+  }
+}

--- a/middlewares/update-config-before-middlewares/index.js
+++ b/middlewares/update-config-before-middlewares/index.js
@@ -1,0 +1,48 @@
+'use strict';
+
+// FIXME: it's a quick hack to modify config before it gets read by other middlewares
+// should use proper methods like finding some pre-middleware hook suited for config updating
+// (strapi hooks run after middlewares, so it's not them)
+module.exports = strapi => {
+  return {
+    /**
+     * Initialize the hook
+     */
+    initialize() {
+      // fill origins if they are not set
+      const self = new URL(strapi.config.origin.self)
+      const prefixes = ['id', 'investor', 'company']
+      prefixes.forEach((prefix) => {
+        if (strapi.config.origin[prefix] === '') {
+          const prefixUrl = new URL('', self)
+          prefixUrl.hostname = `${prefix}.${self.hostname}`
+          strapi.config.origin[prefix] = prefixUrl.origin
+        }
+      })
+
+      // fill domains if they are not set
+      if (strapi.config.hostname.shared === '') {
+        strapi.config.hostname.shared = `.${self.hostname}`
+      }
+
+      if (strapi.config.currentEnvironment.security.cors.enabled === true) {
+        const { origin: initialOrigin } = strapi.config.middleware.settings.cors
+        const initialOriginArray = Array.isArray(initialOrigin)
+          ? initialOrigin
+          : initialOrigin.split(/\s*,\s*/)
+
+        const allowedOrigin = new Set([
+          ...initialOriginArray,
+          strapi.config.origin.self,
+          strapi.config.origin.id,
+          strapi.config.origin.investor,
+          strapi.config.origin.company,
+        ])
+
+        allowedOrigin.delete('')
+
+        strapi.config.middleware.settings.cors.origin = [...allowedOrigin]
+      }
+    },
+  }
+}


### PR DESCRIPTION
It's a quick hack, should be fixed in the future